### PR TITLE
[debug] issue pickup and worktree mapping check

### DIFF
--- a/notes/worktree-debug.md
+++ b/notes/worktree-debug.md
@@ -1,0 +1,26 @@
+# Worktree Debug Note
+
+- **Date:** March 2, 2026
+- **Context:** Trace how issue-specific pickups map to local git worktrees for `trustmee-test` without touching the frontend code.
+
+## Current Worktrees
+
+```
+/Users/mugyeol/git-repos/trustmee-test                       3b7376e [main]
+/Users/mugyeol/git-repos/trustmee-test/.worktrees/issue/1    3b7376e [issue/1]
+/Users/mugyeol/git-repos/trustmee-test/.worktrees/issue/3    3b7376e [issue/3]
+/Users/mugyeol/git-repos/trustmee-test/.worktrees/issue/3-2  3b7376e [issue/3-2]
+/Users/mugyeol/git-repos/trustmee-test/.worktrees/issue/5    3b7376e [issue/5]
+```
+
+## Verification Steps
+
+1. Run `git fetch origin --prune` to keep refs in sync before picking a new issue.
+2. Use `git worktree list` to confirm the target issue already has a dedicated path (see above).
+3. If a worktree is missing, create it with `git worktree add .worktrees/issue/<id> origin/main` and switch branches as needed.
+4. Inside `.worktrees/issue/5`, run `git status -sb` to ensure the worktree is clean before starting implementation.
+
+## Notes
+
+- `issue/5` is mapped to `/Users/mugyeol/git-repos/trustmee-test/.worktrees/issue/5`, which is the current working directory.
+- Keeping these notes in `notes/worktree-debug.md` avoids any unintended frontend diffs.


### PR DESCRIPTION
Closes #5

## 변경 요약
- `notes/worktree-debug.md`에 issue/5 작업트리와 pick-up 검증 절차를 요약한 소규모 노트 파일을 추가했습니다. 프론트엔드 파일은 건드리지 않았습니다.

## 수정된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `notes/worktree-debug.md:1` | 현재 worktree 목록, 신규/기존 issue 작업트리 확인 단계, issue/5 경로 메모 등을 포함한 디버그 노트 추가 |

## 검증 결과
- typecheck: ⏭️ (프로젝트 루트에 CLAUDE.md가 존재하지 않아 실행 명령을 확인할 수 없었고, 문서 추가만 수행했습니다)
- build: ⏭️ (동일 사유)
- unit test: ⏭️ (코드 변경 없음)
- UI 검증: ⏭️ (프론트엔드 변경 없음)

## 셀프리뷰
- 문서 추가만 있어 보안/타입/패턴 리스크가 없습니다.
- 노트 내용이 현행 worktree 출력과 절차를 담고 있어 요구사항 충족을 확인했습니다 (`notes/worktree-debug.md:3`~`notes/worktree-debug.md:26`).

## 리뷰 포인트
- git add/commit 시 `/Users/mugyeol/git-repos/trustmee-test/.git/worktrees/5/index.lock`에 쓸 권한이 없어 스테이지/커밋을 수행하지 못했습니다. 로컬에서 동일 파일을 직접 stage+commit해야 합니다.
- 프론트엔드에는 변동이 없으므로 추가 UI 확인은 필요 없습니다.

## ✅ 결과: 테스트 대기

### 판정 근거
- 요구사항은 문서 추가뿐이며 구현을 완료했고, 타입/빌드 명령은 정의되지 않아 생략했습니다.
- 남은 작업은 권한 문제로 수행하지 못한 git stage/commit뿐이며 코드 자체는 안정적입니다.

---
⏱ **실행 시간**: 2m 30s