### PR TITLE
Todo 디자인 톤앤매너 변경

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,83 +1,104 @@
-@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600&family=Manrope:wght@400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;600&display=swap');
 
 :root {
-  --bg-1: #e6f0ec;
-  --bg-2: #f7f6f2;
-  --ink: #152019;
-  --ink-soft: #516054;
-  --accent: #1f7a53;
-  --accent-strong: #14563a;
-  --line: #d0d9d3;
-  --danger: #a63b32;
-  --card: #ffffffcc;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f5f6fa;
+  --page-bg: #f5f6fa;
+  --surface: #ffffff;
+  --surface-muted: #f8fafc;
+  --border: #e2e8f0;
+  --border-strong: #c7d2fe;
+  --text-strong: #0f172a;
+  --text-soft: #64748b;
+  --accent: #4f46e5;
+  --accent-strong: #3730a3;
+  --accent-soft: rgba(79, 70, 229, 0.16);
+  --danger: #ef4444;
+  --shadow: 0 25px 80px rgba(15, 23, 42, 0.08);
+  --radius-lg: 24px;
+}
+
+::selection {
+  background: var(--accent-soft);
 }
 
 .todo-page {
   min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: 2rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 4vw, 4rem) 1.5rem;
   background:
-    radial-gradient(circle at 20% 10%, #cde5d7 0%, transparent 45%),
-    radial-gradient(circle at 85% 80%, #e6dfca 0%, transparent 40%),
-    linear-gradient(130deg, var(--bg-1), var(--bg-2));
+    linear-gradient(120deg, rgba(255, 255, 255, 0.92), rgba(245, 246, 250, 0.95)),
+    var(--page-bg);
 }
 
 .todo-shell {
-  width: min(760px, 100%);
-  backdrop-filter: blur(8px);
-  background: var(--card);
-  border: 1px solid #ffffff;
-  border-radius: 24px;
-  box-shadow: 0 20px 60px rgba(28, 41, 35, 0.14);
-  padding: clamp(1.2rem, 2.2vw, 2rem);
-  animation: rise 360ms ease-out;
+  width: min(780px, 100%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: clamp(18px, 2vw, 28px);
+  box-shadow: var(--shadow);
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
 }
 
 .todo-header {
-  margin-bottom: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .eyebrow {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font: 700 0.72rem/1 'Manrope', sans-serif;
-  color: var(--ink-soft);
+  letter-spacing: 0.18em;
+  font: 600 0.74rem/1 'Inter', sans-serif;
+  color: var(--text-soft);
 }
 
 h1 {
-  margin: 0.25rem 0 0.2rem;
-  font: 600 clamp(2rem, 4vw, 2.6rem)/1.06 'Fraunces', serif;
-  color: var(--ink);
+  margin: 0;
+  font: 600 clamp(2rem, 4vw, 2.6rem)/1 'Space Grotesk', 'Inter', sans-serif;
+  color: var(--text-strong);
 }
 
 .subtitle {
   margin: 0;
-  font: 400 0.92rem/1.4 'Manrope', sans-serif;
-  color: var(--ink-soft);
+  font: 500 0.95rem/1.5 'Inter', sans-serif;
+  color: var(--text-soft);
 }
 
 .todo-form {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 0.65rem;
-  margin-bottom: 1rem;
+  padding: 0.55rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
 }
 
 .todo-input {
   width: 100%;
-  border-radius: 12px;
-  border: 1px solid var(--line);
-  background: #ffffffd0;
-  padding: 0.82rem 0.9rem;
-  font: 600 0.98rem/1.2 'Manrope', sans-serif;
-  color: var(--ink);
+  border: 0;
+  background: transparent;
+  padding: 0.75rem 0.9rem;
+  font: 500 1rem/1.2 'Inter', sans-serif;
+  color: var(--text-strong);
+}
+
+.todo-input::placeholder {
+  color: var(--text-soft);
 }
 
 .todo-input:focus {
-  outline: 2px solid color-mix(in srgb, var(--accent) 40%, white);
-  outline-offset: 1px;
+  outline: none;
+  background: #fff;
+  box-shadow: 0 0 0 2px var(--border-strong);
 }
 
 .add-btn,
@@ -85,150 +106,190 @@ h1 {
 .ghost-btn,
 .delete-btn {
   border: 0;
-  border-radius: 12px;
-  font: 700 0.88rem/1 'Manrope', sans-serif;
+  border-radius: 999px;
+  font: 600 0.92rem/1 'Inter', sans-serif;
   cursor: pointer;
+  transition: all 160ms ease-in-out;
 }
 
 .add-btn {
-  background: var(--accent);
-  color: #f3fff8;
-  padding: 0 1rem;
+  padding: 0 1.6rem;
+  background: var(--text-strong);
+  color: #fff;
 }
 
 .add-btn:hover {
-  background: var(--accent-strong);
+  background: #111826;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.8rem;
   flex-wrap: wrap;
-  margin-bottom: 1rem;
+  gap: 0.8rem;
 }
 
 .filters {
   display: inline-flex;
-  gap: 0.45rem;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
 }
 
 .filter-btn {
-  border: 1px solid var(--line);
-  background: #fff;
-  color: var(--ink-soft);
-  padding: 0.42rem 0.66rem;
+  background: transparent;
+  color: var(--text-soft);
+  padding: 0.45rem 0.9rem;
+}
+
+.filter-btn:hover {
+  color: var(--text-strong);
 }
 
 .filter-btn.is-active {
-  border-color: var(--accent);
-  background: #ddf4e8;
-  color: var(--accent-strong);
+  background: #fff;
+  color: var(--text-strong);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
 }
 
 .ghost-btn {
-  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 0.48rem 0.9rem;
   background: transparent;
-  color: var(--ink-soft);
-  padding: 0.42rem 0.7rem;
+  border: 1px solid var(--border);
+  color: var(--text-strong);
 }
 
 .ghost-btn:disabled {
-  opacity: 0.44;
+  color: var(--text-soft);
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
 .todo-list {
   list-style: none;
-  padding: 0;
   margin: 0;
-  display: grid;
-  gap: 0.5rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
 }
 
 .todo-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-  border: 1px solid var(--line);
-  border-radius: 12px;
+  gap: 0.85rem;
+  border-radius: 18px;
+  border: 1px solid var(--border);
   background: #fff;
-  padding: 0.65rem 0.7rem;
-  animation: fadeIn 200ms ease-out;
+  padding: 0.85rem 1rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.todo-item:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
 }
 
 .todo-main {
   display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
-  font: 600 0.95rem/1.3 'Manrope', sans-serif;
-  color: var(--ink);
+  gap: 0.75rem;
+  font: 500 1rem/1.4 'Inter', sans-serif;
+  color: var(--text-strong);
+  flex: 1;
 }
 
 .todo-main input[type='checkbox'] {
-  width: 1rem;
-  height: 1rem;
-  accent-color: var(--accent);
+  appearance: none;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  background: #fff;
+  transition: all 150ms ease;
+}
+
+.todo-main input[type='checkbox']::after {
+  content: '';
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 3px;
+  transform: scale(0);
+  background: #fff;
+  transition: transform 120ms ease;
+}
+
+.todo-main input[type='checkbox']:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.todo-main input[type='checkbox']:checked::after {
+  transform: scale(1);
+}
+
+.todo-main input[type='checkbox']:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .todo-item.is-done {
-  opacity: 0.66;
+  background: var(--surface-muted);
+  border-style: dashed;
+  opacity: 0.8;
 }
 
 .todo-item.is-done .todo-main span {
   text-decoration: line-through;
+  color: var(--text-soft);
 }
 
 .delete-btn {
-  border: 1px solid #e6c9c4;
-  background: #fff5f3;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba(239, 68, 68, 0.1);
   color: var(--danger);
-  padding: 0.44rem 0.58rem;
+  padding: 0.45rem 0.8rem;
+}
+
+.delete-btn:hover {
+  border-color: rgba(239, 68, 68, 0.4);
 }
 
 .empty {
+  border-radius: 18px;
+  border: 1px dashed var(--border);
+  background: var(--surface-muted);
+  color: var(--text-soft);
+  font: 500 0.95rem/1.4 'Inter', sans-serif;
   text-align: center;
-  border: 1px dashed var(--line);
-  border-radius: 12px;
-  background: #ffffff80;
-  color: var(--ink-soft);
-  font: 600 0.9rem/1.2 'Manrope', sans-serif;
-  padding: 1rem;
+  padding: 1.5rem 1rem;
 }
 
 .todo-footer {
-  margin-top: 1rem;
-  display: flex;
-  gap: 0.85rem;
-  flex-wrap: wrap;
-  color: var(--ink-soft);
-  font: 700 0.78rem/1 'Manrope', sans-serif;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.8rem;
+}
+
+.todo-footer span {
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 0.7rem 0.9rem;
+  font: 600 0.85rem/1 'Inter', sans-serif;
+  color: var(--text-soft);
+  background: var(--surface-muted);
+  text-align: center;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-@keyframes rise {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 @media (max-width: 540px) {
@@ -237,6 +298,16 @@ h1 {
   }
 
   .add-btn {
-    height: 2.75rem;
+    width: 100%;
+    height: 2.9rem;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .todo-shell {
+    padding: 1.5rem;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,5 +10,8 @@ body,
 }
 
 body {
-  color: #152019;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--page-bg, #f5f6fa);
+  color: var(--text-strong, #0f172a);
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Closes #3

## 변경 요약
- 스킬 사용: brainstorming – 구현 전에 현대적·미니멀 톤과 구성 요소 우선순위를 정리했습니다.
- 루트 팔레트와 폰트 토큰을 재정의해 뉴트럴/보라 포인트 컬러 체계로 통일, 전체 톤앤매너를 리셋했습니다 (`frontend/src/App.css:1`).
- 입력 폼·필터·버튼을 라운드 칩 기반 컨트롤과 깔끔한 호버/디세이블 상태로 재구성해 간결한 상호작용을 제공했습니다 (`frontend/src/App.css:75`, `frontend/src/App.css:125`).
- 카드형 리스트·커스텀 체크박스·통계 칩을 도입해 정보 계층과 접근성을 높였고 focus-visible 처리로 키보드 내비게이션을 보완했습니다 (`frontend/src/App.css:182`, `frontend/src/App.css:208`).
- 글로벌 body 폰트/배경을 Inter와 단색 톤으로 맞춰 페이지 전반의 인상을 현대적으로 정돈했습니다 (`frontend/src/index.css:12`).

## 수정된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `frontend/src/App.css:1` | 새 컬러 토큰, 폰트 스택, 폼·툴바·리스트·체크박스·푸터 칩 스타일, 포커스 처리, 모바일 패딩 조정으로 전체 UI를 미니멀 톤으로 재구성 |
| `frontend/src/index.css:12` | 페이지 전역 폰트·배경·안티앨리어싱 설정을 새 톤에 맞게 정리 |

## 검증 결과
- typecheck: ⏭️ (프로젝트에 별도 typecheck 스크립트 없음)
- build: ✅ (`npm run build`)
- unit test: ⏭️ (테스트 스위트 미제공)
- UI 검증: ⏭️ (dev 서버 미기동 – 수동 시각 확인 필요)

## 셀프리뷰
- 커스텀 입력·체크박스에 focus-visible 스타일을 둬 키보드 접근성 저하가 없도록 확인했습니다 (`frontend/src/App.css:98`, `frontend/src/App.css:239`).
- 변경은 CSS 레이어에 한정되어 로직·데이터 경로를 건드리지 않으므로 보안/타입 리스크는 없습니다.

## 리뷰 포인트
- 실제 브라우저(특히 모바일)에서 새 톤앤매너와 반응형 패딩이 의도한 레이아웃을 유지하는지 확인해 주세요.
- 커스텀 체크박스가 Safari 등 다른 렌더러에서도 올바로 렌더되는지 가벼운 수동 테스트 권장.
- Sandbox에서 `/Users/mugyeol/git-repos/trustmee-test/.git/worktrees/3-2`에 쓰기 권한이 없어 `git add/commit`을 수행하지 못했습니다. 로컬 권한이 있는 환경에서 수동 커밋이 필요합니다.

## ✅ 결과: 테스트 대기

### 판정 근거
- 빌드가 통과했고 변경 범위는 스타일 재구성뿐이므로 재작업 혹은 추가 휴먼 작업 사유가 없습니다.

---
⏱ **실행 시간**: 4m 10s