### PR TITLE
Todo 디자인 톤앤매너 변경  to cybertic

### DIFF
--- a/docs/plans/2026-03-04-todo-cybertic-design.md
+++ b/docs/plans/2026-03-04-todo-cybertic-design.md
@@ -1,0 +1,29 @@
+# Todo cybertic tone & manner — 2026-03-04
+
+## Context & Goals
+The current todo UI is themed after warm retro stationery (beige parchment, rounded cards, offset drop shadows). The new requirement asks for a “cybertic” tone: dark glass panels, neon vaporwave accents, and circuitry-inspired affordances that feel like a command deck. Functionality (local-storage persistence, filters, stats, destructive actions) remains unchanged, so the work is a CSS+copy styling pass that re-skins the existing layout without touching data flow. Success criteria: (1) instant recognition of a futuristic/fiber-optic system through palette, typography, and subtle glow effects, (2) maintain readable contrast (WCAG AA for main text on dark backgrounds), (3) keep accessibility affordances—focus rings, large hit targets, reduced motion fallbacks—and (4) ensure the UI still works at 360px widths. Constraints: no new JS dependencies, no DOM restructuring beyond pseudo elements, and keep performance acceptable (avoid expensive blur filters on large surfaces). The theme should feel like a HUD overlay: layered grids, animated scanning highlights, and luminous outlines. We'll also translate the tone into micro details such as monospaced stats, “holographic” toolbar chips, and digital checkbox indicators.
+
+## Direction Options
+**Option A – Neon Grid Console.** Palette: midnight navy background (#020511 → #050b16), translucent panels (#0c1627, alpha). Accents: cyan (#39d0ff) + magenta (#ff38c3) gradients with electric-green highlight (#a3ff12). Typography: heading in Orbitron 600, body in Space Grotesk 500, monospace details in Share Tech Mono. Decor includes animated grid overlay and sweeping light `::after` across cards. Pros: immediate sci-fi association, easy to implement with CSS gradients. Cons: dark theme requires careful contrast management and more explicit focus outlines.
+**Option B – Chrome Circuit Minimal.** Light background (#e8eef5) with chrome borders, blue accents, condensed grotesk typography. Pros: easier contrast, more minimal. Cons: less “cyberpunk” energy; might still feel like a generic SaaS UI.
+**Option C – Terminal Matrix.** Pure black (#000) background, lime text, ASCII art. Pros: high nostalgia. Cons: monotone, fails readability for long sessions, sacrifices warmth. Option A best meets the “cybertic” goal while allowing expressive gradients and glows without overhauling markup.
+
+## Final Experience Design
+Typography import: `Orbitron` (600) for titles/buttons, `Space Grotesk` (400/500/600) for general text, and `Share Tech Mono` (400) for stats and microcopy. Root tokens:
+- `--page-bg: #02040a`, `--page-bg-2: #050b16` for the canvas gradient.
+- `--surface: rgba(8, 16, 32, 0.8)` translucent panels with backdrop blur (fallback to solid for browsers without blur).
+- `--surface-strong: #0f172a` and `--surface-glow: rgba(57, 208, 255, 0.18)` for layered depths.
+- `--ink: #f3f9ff`, `--muted: #8aa2cb`, `--border: rgba(74, 111, 177, 0.45)`, `--border-strong: #37e5ff`.
+- `--accent: #6f3dff`, `--accent-strong: #ff3df0`, `--accent-subtle: rgba(111, 61, 255, 0.18)`, `--teal: #59f7ff`, `--danger: #ff5470`.
+
+Layout: keep centered shell (max 720px) but switch from rounded parchment to beveled glass: 18px radius, 1px neon border, inner glow. `.todo-page` receives layered background—primary gradient, `::before` radial pulses, `::after` animated grid using `linear-gradient` stripes combined with `animation: driftGrid 40s linear infinite`. `main` uses `overflow: hidden` to keep effects contained.
+
+Header: eyebrow becomes HUD label with `letter-spacing: 0.4em`, neon cyan text, digital caret `›`. Title uses Orbitron uppercase with gradient text fill and `text-shadow` for glow. Subtitle switches to `Share Tech Mono` with accent color, optionally featuring `[SYNCED/LOCAL]` style copy.
+
+Form: `.todo-form` uses minimal gap, with `.todo-input` styled as glass input (transparent background, 1px glowing border, inset cyan focus line). `.add-btn` gets gradient `background: linear-gradient(120deg, var(--accent) 0%, var(--accent-strong) 100%)`, `box-shadow` for holographic glow, and `::after` highlight on hover. Placeholder text uses muted cyan.
+
+Toolbar: convert to segmented chip row on a transparent bar. `.filter-btn` uses uppercase Orbitron, border + box shadow to mimic touch targets; `.is-active` state fills with neon gradient and adds inner glow. `.ghost-btn` now a danger-free “Clear done” text button with dotted border, top-right align.
+
+Todo list: cards adopt `background: var(--surface)`, `border-image` gradient to create glowing edges, `box-shadow: 0 12px 30px rgba(4, 8, 16, 0.6)`. Each `.todo-item` adds `::before` diagonal sheen animation triggered on hover. Checkbox becomes 18px square with gradient fill, drop shadow, and SVG-like check via pseudo element. Done items dim and add `text-shadow` removal plus `border-color: rgba(255,255,255,0.1)` to feel disabled. Empty state uses dashed neon border and ASCII-style copy.
+
+Footer stats use pills with translucent backgrounds and a subtle scanline GIF simulation via CSS animation (pure CSS stripes). Provide `prefers-reduced-motion` overrides to disable glow animations. Testing: run `npm run build` for regression + manual keyboard traversal to ensure focus-visible outlines remain high-contrast. EOF

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,20 +1,25 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Syne:wght@600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500;600&family=Share+Tech+Mono&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
-  --page-bg: #fff5dd;
-  --page-bg-2: #fde2b5;
-  --surface: #fffaf0;
-  --ink: #2f1a12;
-  --muted: #6e4b3a;
-  --border: #f0d3ae;
-  --border-strong: #d3a264;
-  --accent: #d75a28;
-  --accent-strong: #a63c16;
-  --accent-subtle: #ffe1c7;
-  --teal: #1a8b8f;
-  --danger: #bb1e40;
-  --shadow-soft: 0 28px 80px rgba(71, 33, 13, 0.2);
-  --shadow-card: 0 12px 32px rgba(47, 26, 18, 0.2);
+  --page-bg: #02040a;
+  --page-bg-2: #050b16;
+  --surface: rgba(6, 12, 26, 0.88);
+  --surface-strong: rgba(11, 20, 38, 0.95);
+  --surface-glass: rgba(9, 16, 32, 0.65);
+  --ink: #f4fbff;
+  --muted: #8ca2cc;
+  --muted-strong: #5b6f97;
+  --border: rgba(82, 115, 190, 0.55);
+  --border-strong: #37e5ff;
+  --accent: #6f3dff;
+  --accent-strong: #ff3df0;
+  --accent-subtle: rgba(111, 61, 255, 0.2);
+  --accent-alt: #2be4ff;
+  --teal: #59f7ff;
+  --danger: #ff5470;
+  --danger-border: rgba(255, 84, 112, 0.6);
+  --shadow-soft: 0 30px 80px rgba(0, 0, 0, 0.6);
+  --shadow-card: 0 18px 40px rgba(2, 8, 20, 0.75);
 }
 
 :focus-visible {
@@ -23,8 +28,8 @@
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--accent) 35%, white);
-  color: var(--surface);
+  background: rgba(111, 61, 255, 0.85);
+  color: #010104;
 }
 
 .todo-page {
@@ -32,44 +37,44 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(1.5rem, 5vw, 4rem);
-  background: linear-gradient(180deg, var(--page-bg) 0%, var(--page-bg-2) 100%);
+  padding: clamp(1rem, 4vw, 4rem);
+  background: radial-gradient(circle at top, #061129 0%, var(--page-bg-2) 50%, var(--page-bg) 100%);
   position: relative;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .todo-page::before,
 .todo-page::after {
   content: '';
   position: absolute;
-  inset: -10%;
+  inset: -40%;
   pointer-events: none;
+  z-index: -1;
 }
 
 .todo-page::before {
-  background-image: radial-gradient(rgba(215, 90, 40, 0.08) 1px, transparent 1px),
-    radial-gradient(rgba(26, 139, 143, 0.08) 1px, transparent 1px);
-  background-size: 140px 140px, 100px 100px;
-  mix-blend-mode: multiply;
-  opacity: 0.6;
+  background: radial-gradient(circle at 20% 20%, rgba(43, 228, 255, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(255, 61, 240, 0.25), transparent 40%),
+    radial-gradient(circle at 50% 80%, rgba(111, 61, 255, 0.2), transparent 35%);
+  animation: pulseField 12s ease-in-out infinite;
+  mix-blend-mode: screen;
+  opacity: 0.85;
 }
 
 .todo-page::after {
   background-image: repeating-linear-gradient(
-      0deg,
-      rgba(255, 255, 255, 0.07),
-      rgba(255, 255, 255, 0.07) 2px,
-      transparent 2px,
-      transparent 4px
+      transparent 0 94px,
+      rgba(55, 229, 255, 0.15) 94px 96px
     ),
     repeating-linear-gradient(
       90deg,
-      rgba(0, 0, 0, 0.04),
-      rgba(0, 0, 0, 0.04) 1px,
-      transparent 1px,
-      transparent 4px
+      transparent 0 94px,
+      rgba(111, 61, 255, 0.12) 94px 96px
     );
   opacity: 0.25;
+  animation: driftGrid 40s linear infinite;
+  mix-blend-mode: screen;
 }
 
 .todo-shell {
@@ -77,71 +82,82 @@
   position: relative;
   isolation: isolate;
   background: var(--surface);
-  border: 2px solid var(--border);
+  border: 1px solid var(--border);
   border-radius: 28px;
-  padding: clamp(1.75rem, 3vw, 3rem);
-  box-shadow: var(--shadow-soft);
+  padding: clamp(1.5rem, 3vw, 3rem);
+  box-shadow: var(--shadow-soft), 0 0 40px rgba(43, 228, 255, 0.25);
   display: flex;
   flex-direction: column;
   gap: 1.35rem;
+  backdrop-filter: blur(22px);
   animation: fadeSlideUp 420ms ease-out;
 }
 
 .todo-shell::before {
   content: '';
   position: absolute;
-  inset: 0;
-  border: 2px solid var(--border-strong);
-  border-radius: 26px;
-  transform: translate(14px, 12px);
-  background: var(--surface);
-  z-index: -2;
-  opacity: 0.85;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(120deg, rgba(43, 228, 255, 0.7), rgba(111, 61, 255, 0.6));
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  opacity: 0.4;
 }
 
 .todo-shell::after {
   content: '';
   position: absolute;
-  width: 120px;
-  height: 28px;
-  top: 1.25rem;
-  right: clamp(1.2rem, 4vw, 3.5rem);
-  background: var(--accent-subtle);
-  box-shadow: 0 10px 24px rgba(167, 60, 22, 0.25);
-  transform: rotate(2deg);
-  opacity: 0.75;
-  border-radius: 6px;
-  mix-blend-mode: multiply;
-  z-index: -1;
+  inset: 10% 15% auto;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(111, 61, 255, 0.7), transparent);
+  filter: blur(1px);
+  mix-blend-mode: screen;
+  opacity: 0.6;
 }
 
 .todo-header {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.35rem;
 }
 
 .eyebrow {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.24em;
-  font: 700 0.75rem/1 'Space Mono', 'Courier New', Courier, monospace;
-  color: var(--teal);
+  letter-spacing: 0.4em;
+  font: 600 0.8rem/1 'Share Tech Mono', 'Space Mono', 'Courier New', Courier, monospace;
+  color: var(--accent-alt);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.eyebrow::after {
+  content: '›';
+  font-size: 1rem;
 }
 
 h1 {
   margin: 0;
-  font: 700 clamp(2.1rem, 5vw, 3.2rem)/1.05 'Syne', 'Space Mono', 'Courier New', Courier, monospace;
-  color: var(--ink);
+  font: 600 clamp(2.1rem, 5vw, 3.4rem)/1 'Orbitron', 'Space Grotesk', 'Space Mono', 'Courier New', Courier, monospace;
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  background: linear-gradient(110deg, var(--ink), #a4d7ff 40%, #ffffff 70%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 0 20px rgba(89, 247, 255, 0.35);
 }
 
 .subtitle {
   margin: 0;
-  font: 400 1rem/1.5 'Space Mono', 'Courier New', Courier, monospace;
+  font: 400 0.95rem/1.5 'Share Tech Mono', 'Space Mono', 'Courier New', Courier, monospace;
   color: var(--muted);
-  font-style: italic;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
 }
 
 .todo-form {
@@ -154,41 +170,42 @@ h1 {
 .todo-input {
   width: 100%;
   border-radius: 18px;
-  border: 2px solid var(--border);
-  background: var(--surface);
+  border: 1px solid var(--border);
+  background: var(--surface-glass);
   padding: 0 1.3rem;
   height: 3.5rem;
-  font: 700 1rem/1 'Space Mono', 'Courier New', Courier, monospace;
+  font: 500 1rem/1 'Space Grotesk', 'Share Tech Mono', 'Courier New', Courier, monospace;
   color: var(--ink);
-  box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.06);
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
 
 .todo-input::placeholder {
-  color: color-mix(in srgb, var(--muted) 55%, #fff);
-  font-style: italic;
+  color: rgba(143, 187, 255, 0.55);
+  font-style: normal;
+  letter-spacing: 0.08em;
 }
 
 .todo-input:focus-visible {
-  border-color: var(--teal);
-  box-shadow: inset 0 -6px 0 rgba(26, 139, 143, 0.15);
+  border-color: var(--border-strong);
+  box-shadow: 0 0 25px rgba(55, 229, 255, 0.25), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   transform: translateY(-1px);
 }
 
 button {
-  font-family: 'Syne', 'Space Mono', 'Courier New', Courier, monospace;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-family: 'Orbitron', 'Space Grotesk', 'Share Tech Mono', 'Courier New', Courier, monospace;
+  font-weight: 600;
+  letter-spacing: 0.1em;
   border-radius: 18px;
   border: 0;
   text-transform: uppercase;
   cursor: pointer;
-  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease,
-    color 160ms ease, border-color 160ms ease;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, color 180ms ease,
+    border-color 180ms ease;
 }
 
 button:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
@@ -200,17 +217,33 @@ button:focus-visible {
 }
 
 .add-btn {
-  min-width: 140px;
+  min-width: 150px;
   height: 3.5rem;
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
-  color: var(--surface);
-  box-shadow: 0 2px 0 #87300f, 0 14px 25px rgba(167, 60, 22, 0.45);
-  border: 2px solid #87300f;
+  background: linear-gradient(120deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #05030d;
+  box-shadow: 0 15px 35px rgba(255, 61, 240, 0.35), 0 0 30px rgba(111, 61, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+.add-btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, rgba(255, 255, 255, 0.3), transparent 60%);
+  mix-blend-mode: screen;
+  opacity: 0;
+  transition: opacity 180ms ease;
 }
 
 .add-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 0 #87300f, 0 20px 30px rgba(167, 60, 22, 0.4);
+  box-shadow: 0 20px 35px rgba(255, 61, 240, 0.4), 0 0 40px rgba(111, 61, 255, 0.4);
+}
+
+.add-btn:hover::after {
+  opacity: 0.8;
 }
 
 .toolbar {
@@ -219,45 +252,67 @@ button:focus-visible {
   justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
-  background: var(--accent-subtle);
-  border: 2px solid var(--border);
+  background: rgba(7, 13, 30, 0.7);
+  border: 1px solid var(--border);
   border-radius: 999px;
-  padding: 0.4rem 0.5rem;
-  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.05);
+  padding: 0.4rem 0.6rem;
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.35), 0 0 20px rgba(0, 0, 0, 0.25);
 }
 
 .filters {
   display: flex;
-  gap: 0.3rem;
+  gap: 0.4rem;
+  flex-wrap: wrap;
 }
 
 .filter-btn {
-  padding: 0.5rem 1.2rem;
+  padding: 0.55rem 1.4rem;
   border-radius: 999px;
   background: transparent;
-  border: 2px solid transparent;
+  border: 1px solid transparent;
   color: var(--muted);
+  position: relative;
+}
+
+.filter-btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(43, 228, 255, 0.6), rgba(111, 61, 255, 0.4));
+  opacity: 0;
+  transition: opacity 180ms ease;
+  mix-blend-mode: screen;
+}
+
+.filter-btn:hover::after {
+  opacity: 0.45;
 }
 
 .filter-btn.is-active {
-  background: var(--surface);
+  background: linear-gradient(120deg, rgba(43, 228, 255, 0.18), rgba(111, 61, 255, 0.35));
   color: var(--ink);
-  border-color: var(--teal);
-  box-shadow: 0 4px 12px rgba(26, 139, 143, 0.25);
+  border-color: var(--border-strong);
+  box-shadow: 0 0 20px rgba(55, 229, 255, 0.4);
+}
+
+.filter-btn.is-active::after {
+  opacity: 0.7;
 }
 
 .ghost-btn {
   padding: 0.55rem 1.2rem;
   border-radius: 999px;
-  border: 2px dashed var(--border-strong);
-  background: var(--surface);
+  border: 1px dashed var(--border-strong);
+  background: transparent;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
 }
 
 .ghost-btn:hover:not(:disabled) {
-  border-style: solid;
   color: var(--ink);
+  border-style: solid;
 }
 
 .todo-list {
@@ -274,23 +329,35 @@ button:focus-visible {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  border: 2px solid var(--border);
+  border: 1px solid var(--border);
   border-radius: 24px;
-  background: var(--surface);
+  background: var(--surface-strong);
   padding: 1rem 1.3rem;
   box-shadow: var(--shadow-card);
   position: relative;
   overflow: hidden;
-  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease, background 200ms ease;
+}
+
+.todo-item::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(43, 228, 255, 0.1), rgba(111, 61, 255, 0.18));
+  opacity: 0;
+  transition: opacity 220ms ease;
 }
 
 .todo-item::after {
   content: '';
   position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, transparent 65%, rgba(255, 255, 255, 0.35));
+  inset: -30% 10% auto;
+  height: 120%;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.15), transparent 70%);
   opacity: 0;
-  transition: opacity 200ms ease;
+  transform: translateX(-40%);
+  transition: opacity 220ms ease, transform 220ms ease;
 }
 
 .todo-item:hover {
@@ -298,13 +365,18 @@ button:focus-visible {
   border-color: var(--border-strong);
 }
 
-.todo-item:hover::after {
+.todo-item:hover::before {
   opacity: 1;
 }
 
+.todo-item:hover::after {
+  opacity: 0.6;
+  transform: translateX(0);
+}
+
 .todo-item.is-done {
-  background: #fff1df;
-  border-color: var(--border-strong);
+  background: rgba(8, 12, 26, 0.65);
+  border-color: rgba(255, 255, 255, 0.08);
   opacity: 0.85;
 }
 
@@ -312,30 +384,30 @@ button:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 0.95rem;
-  font: 700 1rem/1.3 'Space Mono', 'Courier New', Courier, monospace;
+  font: 500 1rem/1.3 'Space Grotesk', 'Share Tech Mono', 'Courier New', Courier, monospace;
   color: var(--ink);
 }
 
 .todo-main input[type='checkbox'] {
   appearance: none;
-  width: 1.35rem;
-  height: 1.35rem;
-  border-radius: 8px;
-  border: 2px solid var(--ink);
-  background: var(--surface);
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-strong);
+  background: rgba(12, 21, 38, 0.8);
   display: grid;
   place-items: center;
   margin: 0;
   position: relative;
-  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
 }
 
 .todo-main input[type='checkbox']::after {
   content: '';
-  width: 0.35rem;
-  height: 0.75rem;
-  border: 0.2rem solid var(--surface);
+  width: 0.45rem;
+  height: 0.9rem;
+  border: 0.2rem solid var(--ink);
   border-top: 0;
   border-left: 0;
   transform: rotate(45deg);
@@ -344,9 +416,9 @@ button:focus-visible {
 }
 
 .todo-main input[type='checkbox']:checked {
-  background: var(--teal);
-  border-color: var(--teal);
-  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.25);
+  background: linear-gradient(130deg, var(--accent-alt), var(--accent-strong));
+  border-color: var(--accent-alt);
+  box-shadow: 0 0 12px rgba(43, 228, 255, 0.55);
 }
 
 .todo-main input[type='checkbox']:checked::after {
@@ -358,33 +430,35 @@ button:focus-visible {
 }
 
 .todo-item.is-done .todo-main span {
-  color: var(--muted);
+  color: var(--muted-strong);
   text-decoration: line-through;
 }
 
 .delete-btn {
-  background: var(--danger);
-  color: var(--surface);
-  padding: 0.4rem 0.8rem;
-  border: 2px solid #6e0d20;
+  background: transparent;
+  color: var(--danger);
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--danger-border);
   border-radius: 14px;
-  box-shadow: 0 2px 0 #6e0d20, 0 10px 18px rgba(110, 13, 32, 0.3);
-  font-size: 0.75rem;
-  letter-spacing: 0.04em;
+  box-shadow: 0 0 20px rgba(255, 84, 112, 0.2);
+  font-size: 0.7rem;
 }
 
 .delete-btn:hover:not(:disabled) {
+  background: rgba(255, 84, 112, 0.1);
   transform: translateY(-2px);
 }
 
 .empty {
   text-align: center;
-  border: 2px dashed var(--border-strong);
+  border: 1px dashed var(--border-strong);
   border-radius: 24px;
-  background: color-mix(in srgb, var(--surface) 90%, white);
+  background: rgba(6, 12, 26, 0.6);
   color: var(--muted);
-  font: italic 700 0.95rem/1.4 'Space Mono', 'Courier New', Courier, monospace;
+  font: 600 0.9rem/1.6 'Share Tech Mono', 'Space Mono', 'Courier New', Courier, monospace;
   padding: 1.4rem 1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .todo-footer {
@@ -395,14 +469,30 @@ button:focus-visible {
 }
 
 .todo-footer span {
-  border: 2px solid var(--border);
+  border: 1px solid var(--border);
   border-radius: 12px;
-  padding: 0.5rem 0.85rem;
-  font: 700 0.85rem/1 'Space Mono', 'Courier New', Courier, monospace;
+  padding: 0.55rem 0.9rem;
+  font: 600 0.75rem/1 'Share Tech Mono', 'Space Mono', 'Courier New', Courier, monospace;
   text-transform: uppercase;
   color: var(--ink);
-  background: var(--accent-subtle);
-  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.15);
+  background: rgba(9, 18, 34, 0.8);
+  position: relative;
+  overflow: hidden;
+}
+
+.todo-footer span::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.06),
+    rgba(255, 255, 255, 0.06) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  opacity: 0.4;
+  animation: scanline 6s linear infinite;
 }
 
 .empty,
@@ -421,13 +511,39 @@ button:focus-visible {
   }
 }
 
+@keyframes driftGrid {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(50px, 50px, 0);
+  }
+}
+
+@keyframes pulseField {
+  0%,
+  100% {
+    opacity: 0.7;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+}
+
+@keyframes scanline {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
+  }
+}
+
 @media (max-width: 560px) {
   .todo-shell {
     padding: 1.5rem;
-  }
-
-  .todo-shell::before {
-    transform: translate(8px, 9px);
   }
 
   .todo-form {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -73,7 +73,7 @@ function App() {
         <header className="todo-header">
           <p className="eyebrow">Trustmee Test Project</p>
           <h1>Todo List</h1>
-          <p className="subtitle">Dashboard automation demo target</p>
+          <p className="subtitle">[LOCAL NODE // STORAGE ACTIVE]</p>
         </header>
 
         <form className="todo-form" onSubmit={addTodo}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,8 +10,9 @@ body,
 }
 
 body {
-  font-family: 'Space Mono', 'Courier New', Courier, monospace;
+  font-family: 'Space Grotesk', 'Share Tech Mono', 'Courier New', Courier, monospace;
   color: var(--ink);
-  background: linear-gradient(180deg, var(--page-bg) 0%, var(--page-bg-2) 100%);
+  background: radial-gradient(circle at top, #061129 0%, var(--page-bg-2) 50%, var(--page-bg) 100%);
   text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Closes #14

## 변경 요약
- 새 cybertic HUD 방향에 맞춰 팔레트, 타이포, 배경/그리드 애니메이션, 글래스 섀도우 프레임 등 비주얼 시스템을 재설계해 Todo 페이지 전반을 네온 톤으로 전환 (`frontend/src/App.css:1`, `frontend/src/App.css:35`, `frontend/src/App.css:80`).
- 입력/버튼/필터/리스트/체크박스/푸터 스탯 등 모든 상호작용 컴포넌트를 새로운 톤에 맞게 재스타일링하면서 포커스 링과 `prefers-reduced-motion` 대응을 유지 (`frontend/src/App.css:170`, `frontend/src/App.css:249`, `frontend/src/App.css:327`, `frontend/src/App.css:391`, `frontend/src/App.css:471`).
- HUD 톤을 설명하는 설계 문서를 추가하고, 글로벌 카피·폰트를 동일 컨셉으로 조정 (`docs/plans/2026-03-04-todo-cybertic-design.md:1`, `frontend/src/App.jsx:74`, `frontend/src/index.css:1`).

## 수정된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `docs/plans/2026-03-04-todo-cybertic-design.md:1` | cybertic 톤/팔레트/컴포넌트 접근을 문서화하여 구현 기준을 명시. |
| `frontend/src/App.css:1` | 네온 팔레트·폰트 임포트, 배경/그리드 애니메이션, 글래스 카드, 컨트롤, 리스트, 체크박스, 스탯을 cybertic HUD 스타일로 전면 재구성. |
| `frontend/src/App.jsx:74` | 서브타이틀 카피를 HUD 상태 메시지로 교체. |
| `frontend/src/index.css:1` | 전역 폰트 패밀리와 배경 그라디언트를 신규 테마에 맞게 조정. |

## 검증 결과
- typecheck: ⏭️ (정의된 별도 명령 없음)
- build: ✅ (`npm run build`)
- unit test: ⏭️ (해당 없음)
- UI 검증: ⏭️ (dev server 미실행)

## 셀프리뷰
- 보안: 로직/데이터 경로에 손대지 않고 스타일만 변경하여 XSS·인젝션 리스크 없음.
- 타입 안정성: JS/TS 구조를 변경하지 않아 기존 타입 흐름 유지.
- 패턴 일관성: 기존 단일 컬럼 레이아웃과 상태 관리 방식을 그대로 두고 CSS 토큰/애니메이션만 교체, 포커스 링·reduced-motion 대응 유지.

## 리뷰 포인트
- 다크 모드 대비가 충분한지(특히 완료 아이템 텍스트, 비활성 버튼) 브라우저에서 실제 측정 필요.
- `backdrop-filter`/`mask-composite`를 사용하는 네온 경계가 Firefox 등에서 어떻게 폴백되는지 시각 확인 권장.
- 애니메이션과 글로우가 저사양 기기에서 과도하지 않은지, 필요 시 추가 완화 옵션 고려.

## ✅ 결과: 테스트 대기

### 판정 근거
- 요구된 cybertic 톤 적용 및 설계 문서화 완료, 기능적 변화 없음.
- `npm run build` 성공으로 빌드 무결성 확인.
- 추가 인프라/환경변수/DB 작업 없이 코드만으로 요구사항 충족.

---
⏱ **실행 시간**: 3m 43s