### PR TITLE
Feat : Design 변경

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,29 +1,31 @@
-@import url('https://fonts.googleapis.com/css2?family=Noto+Serif+KR:wght@400;500;600&family=Song+Myung&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap');
 
 :root {
-  --desk-wood: #c48a4c;
-  --desk-wood-dark: #8e5a2f;
-  --paper: #fdf7ec;
-  --paper-dark: #f2e6cf;
-  --paper-edge: rgba(62, 38, 18, 0.25);
-  --ink: #2b1b11;
-  --ink-muted: #6d5b4a;
-  --accent-sage: #7f8b54;
-  --accent-sage-light: #bfc78b;
-  --accent-gold: #c19a4a;
-  --accent-stamp: #c24132;
-  --shadow-parchment: 0 28px 60px rgba(43, 23, 9, 0.3);
-  --shadow-soft: 0 18px 40px rgba(36, 20, 9, 0.2);
+  --win-bg: #008080;
+  --win-face: #c0c0c0;
+  --win-light: #ffffff;
+  --win-mid: #808080;
+  --win-dark: #000000;
+  --win-title: #000080;
+  --win-title-text: #ffffff;
+  --accent-hot: #ff00ff;
+  --accent-lime: #00ff00;
+  --accent-cyan: #00ffff;
+  --accent-yellow: #ffff00;
+  --text-primary: #000000;
+  --text-muted: #404040;
+  --link-blue: #0000ff;
+  --danger: #ff0000;
 }
 
 :focus-visible {
-  outline: 3px solid var(--accent-gold);
-  outline-offset: 4px;
+  outline: 2px dotted var(--accent-hot);
+  outline-offset: 2px;
 }
 
 ::selection {
-  background: rgba(194, 65, 50, 0.25);
-  color: var(--ink);
+  background: var(--win-title);
+  color: var(--win-title-text);
 }
 
 .todo-page {
@@ -31,364 +33,348 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(1.5rem, 4vw, 4rem);
-  background: radial-gradient(circle at 30% 20%, #fdf2df 0%, #f1e0c8 55%, #d9c0a4 100%);
+  padding: clamp(1rem, 4vw, 3rem);
+  background-color: var(--win-bg);
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(0, 255, 255, 0.15) 0%, transparent 40%),
+    radial-gradient(circle at 80% 70%, rgba(255, 0, 255, 0.1) 0%, transparent 40%);
   position: relative;
   overflow: hidden;
   isolation: isolate;
+  image-rendering: pixelated;
 }
 
-.todo-page::before,
-.todo-page::after {
+.todo-page::before {
   content: '';
   position: absolute;
   inset: 0;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="4" height="4"%3E%3Crect width="1" height="1" fill="rgba(0,0,0,0.08)"/%3E%3C/svg%3E');
   pointer-events: none;
   z-index: -1;
 }
 
-.todo-page::before {
-  background-image: radial-gradient(circle at 15% 15%, rgba(157, 130, 89, 0.2), transparent 40%),
-    radial-gradient(circle at 75% 20%, rgba(219, 180, 140, 0.2), transparent 35%),
-    linear-gradient(120deg, rgba(255, 255, 255, 0.08), transparent);
-  mix-blend-mode: multiply;
-}
-
-.todo-page::after {
-  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200"%3E%3Crect width="200" height="200" fill="none"/%3E%3Cpath d="M0 199h200M0 1h200M1 0v200M199 0v200" stroke="rgba(117,86,44,0.08)" stroke-width="1"/%3E%3C/svg%3E');
-  opacity: 0.35;
-  mix-blend-mode: multiply;
-}
-
 .todo-shell {
-  width: min(720px, 100%);
-  background: var(--paper);
-  border-radius: 32px;
-  border: 1.5px solid rgba(67, 40, 18, 0.15);
-  padding: clamp(1.6rem, 3.6vw, 3rem);
-  box-shadow: var(--shadow-parchment);
-  position: relative;
+  width: min(640px, 100%);
+  background: var(--win-face);
+  border: 2px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  padding: 0;
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.5);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  isolation: isolate;
-}
-
-.todo-shell::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  mix-blend-mode: soft-light;
-  pointer-events: none;
-}
-
-.todo-shell::after {
-  content: '';
-  position: absolute;
-  inset: 8% 6% 10% 6%;
-  border-radius: 24px;
-  border: 1px dashed rgba(61, 38, 20, 0.25);
-  pointer-events: none;
-  opacity: 0.7;
+  gap: 0;
 }
 
 .todo-header {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0;
 }
 
 .eyebrow {
   margin: 0;
-  font: 500 0.8rem/1 'Noto Serif KR', 'Song Myung', serif;
-  letter-spacing: 0.5em;
-  text-transform: uppercase;
-  color: var(--ink-muted);
-  display: inline-flex;
+  background: linear-gradient(90deg, var(--win-title), #1084d0);
+  color: var(--win-title-text);
+  font: bold 0.85rem/1 'VT323', monospace;
+  letter-spacing: 0.05em;
+  padding: 4px 8px;
+  display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.5rem;
+  text-transform: none;
 }
 
 .eyebrow::before {
   content: '';
-  width: 24px;
-  height: 1px;
-  background: var(--ink-muted);
+  width: 16px;
+  height: 16px;
+  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-hot));
+  border: 1px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  flex-shrink: 0;
 }
 
 h1 {
   margin: 0;
-  font-family: 'Song Myung', 'Noto Serif KR', serif;
-  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  font-family: 'Press Start 2P', 'VT323', monospace;
+  font-size: clamp(1.2rem, 3.5vw, 1.6rem);
   font-weight: 400;
-  color: var(--ink);
-  letter-spacing: 0.06em;
+  color: var(--text-primary);
+  letter-spacing: 0.02em;
   text-transform: none;
-  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.4), -2px -2px 0 rgba(43, 27, 17, 0.1);
+  text-shadow: 2px 2px 0 var(--accent-cyan);
+  padding: 1rem 1rem 0.4rem;
+  text-align: center;
 }
 
 .subtitle {
   margin: 0;
-  font: 400 1rem/1.5 'Noto Serif KR', 'Song Myung', serif;
-  color: var(--ink-muted);
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  border-top: 1px dotted rgba(54, 33, 18, 0.3);
-  padding-top: 0.4rem;
+  font: 400 1.1rem/1.5 'VT323', monospace;
+  color: var(--text-muted);
+  letter-spacing: 0.1em;
+  text-transform: none;
+  text-align: center;
+  padding: 0 1rem 0.8rem;
+  border-bottom: none;
+  padding-top: 0;
+}
+
+.subtitle::before {
+  content: '>> ';
+  color: var(--accent-hot);
+}
+
+.subtitle::after {
+  content: ' <<';
+  color: var(--accent-hot);
 }
 
 .todo-form {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1rem;
+  gap: 0.5rem;
   align-items: center;
+  padding: 0 0.8rem;
+  margin-bottom: 0.5rem;
 }
 
 .todo-input {
   width: 100%;
-  border-radius: 18px;
-  border: 2px solid rgba(70, 44, 21, 0.35);
-  background: linear-gradient(180deg, var(--paper-dark), var(--paper));
-  padding: 0 1.4rem;
-  height: 3.4rem;
-  font: 500 1rem/1.2 'Noto Serif KR', serif;
-  color: var(--ink);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35), inset 0 3px 12px rgba(56, 39, 21, 0.15);
-  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+  border: 2px solid;
+  border-color: var(--win-dark) var(--win-light) var(--win-light) var(--win-dark);
+  border-radius: 0;
+  background: #ffffff;
+  padding: 0 0.6rem;
+  height: 2.4rem;
+  font: 400 1.2rem/1 'VT323', monospace;
+  color: var(--text-primary);
+  box-shadow: none;
+  transition: none;
 }
 
 .todo-input::placeholder {
-  color: rgba(109, 91, 74, 0.7);
-  font-style: italic;
+  color: var(--win-mid);
+  font-style: normal;
 }
 
 .todo-input:focus-visible {
-  border-color: var(--accent-sage);
-  box-shadow: 0 0 0 3px rgba(191, 199, 139, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.6);
-  transform: translateY(-1px);
+  border-color: var(--win-dark) var(--win-light) var(--win-light) var(--win-dark);
+  box-shadow: inset 0 0 0 1px var(--accent-hot);
+  outline: none;
+  transform: none;
 }
 
 button {
-  font-family: 'Noto Serif KR', 'Song Myung', serif;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  border-radius: 18px;
+  font-family: 'VT323', monospace;
+  font-weight: 400;
+  font-size: 1.1rem;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  border-radius: 0;
   cursor: pointer;
-  border: 0;
-  transition: transform 180ms ease, box-shadow 180ms ease, color 180ms ease, background 180ms ease;
+  border: 2px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  background: var(--win-face);
+  color: var(--text-primary);
+  transition: none;
+}
+
+button:active:not(:disabled) {
+  border-color: var(--win-dark) var(--win-light) var(--win-light) var(--win-dark);
+  padding-top: 2px;
+  padding-left: 2px;
 }
 
 button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  transform: none;
 }
 
 button:focus-visible {
-  outline: 3px solid var(--accent-gold);
-  outline-offset: 3px;
+  outline: 2px dotted var(--accent-hot);
+  outline-offset: 2px;
 }
 
 .add-btn {
-  min-width: 150px;
-  height: 3.4rem;
-  background: linear-gradient(130deg, var(--accent-sage-light), var(--accent-sage));
-  color: #1f240f;
-  border: 1px solid rgba(55, 40, 20, 0.25);
-  box-shadow: var(--shadow-soft);
+  min-width: 100px;
+  height: 2.4rem;
+  background: var(--win-face);
+  color: var(--text-primary);
+  border: 2px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  box-shadow: none;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
+  font-size: 1.2rem;
+  padding: 0 1rem;
 }
 
 .add-btn::after,
 .add-btn::before {
-  content: '';
-  position: absolute;
-  width: 36px;
-  height: 36px;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  border-radius: 50%;
-  top: 50%;
-  transform: translateY(-50%);
-  opacity: 0.3;
-}
-
-.add-btn::before {
-  left: 12px;
-}
-
-.add-btn::after {
-  right: 12px;
+  content: none;
 }
 
 .add-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 35px rgba(63, 86, 47, 0.35);
+  background: #dfdfdf;
+  transform: none;
+  box-shadow: none;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
-  background: linear-gradient(180deg, rgba(237, 217, 185, 0.9), rgba(222, 196, 157, 0.9));
-  border-radius: 26px;
-  border: 1.5px solid rgba(96, 63, 31, 0.35);
-  padding: 0.5rem 0.8rem;
-  box-shadow: inset 0 4px 10px rgba(255, 255, 255, 0.35);
+  background: var(--win-face);
+  border: none;
+  border-top: 2px solid;
+  border-top-color: var(--win-mid);
+  border-bottom: 2px solid;
+  border-bottom-color: var(--win-mid);
+  border-radius: 0;
+  padding: 0.4rem 0.8rem;
+  box-shadow: none;
+  margin: 0;
 }
 
 .filters {
   display: flex;
-  gap: 0.45rem;
+  gap: 0.3rem;
   flex-wrap: wrap;
 }
 
 .filter-btn {
-  padding: 0.5rem 1.2rem;
-  border-radius: 999px;
-  background: transparent;
-  border: 1px dashed rgba(92, 58, 30, 0.5);
-  color: var(--ink-muted);
-  font-size: 0.7rem;
-  letter-spacing: 0.2em;
+  padding: 0.25rem 0.8rem;
+  border-radius: 0;
+  background: var(--win-face);
+  border: 2px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  color: var(--text-primary);
+  font-size: 1rem;
+  letter-spacing: 0.02em;
   position: relative;
 }
 
 .filter-btn::after {
-  content: '';
-  position: absolute;
-  inset: 4px;
-  border-radius: inherit;
-  border: 1px solid transparent;
-  pointer-events: none;
+  content: none;
 }
 
 .filter-btn:hover:not(.is-active) {
-  color: var(--ink);
+  background: #dfdfdf;
+  color: var(--text-primary);
   border-style: solid;
 }
 
 .filter-btn.is-active {
-  background: rgba(191, 199, 139, 0.4);
-  border-color: var(--accent-sage);
-  color: var(--ink);
-  box-shadow: 0 8px 18px rgba(76, 108, 63, 0.25);
+  background: var(--win-title);
+  border-color: var(--win-dark) var(--win-light) var(--win-light) var(--win-dark);
+  color: var(--win-title-text);
+  box-shadow: none;
 }
 
 .filter-btn.is-active::after {
-  border-color: rgba(255, 255, 255, 0.6);
+  content: none;
 }
 
 .ghost-btn {
-  padding: 0.55rem 1.2rem;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(194, 65, 50, 0.4);
-  color: var(--accent-stamp);
-  font-size: 0.7rem;
-  letter-spacing: 0.25em;
-  text-transform: uppercase;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+  padding: 0.25rem 0.8rem;
+  border-radius: 0;
+  background: var(--win-face);
+  border: 2px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  color: var(--danger);
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  box-shadow: none;
 }
 
 .ghost-btn:hover:not(:disabled) {
-  background: rgba(194, 65, 50, 0.1);
-  color: var(--ink);
+  background: var(--danger);
+  color: #ffffff;
 }
 
 .todo-list {
   list-style: none;
-  padding: 0;
+  padding: 0.5rem 0.8rem;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.4rem;
 }
 
 .todo-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  border: 1.5px solid rgba(73, 44, 22, 0.25);
-  border-radius: 28px;
-  background: linear-gradient(180deg, #fdf5e4, #f7ebd4);
-  padding: 1rem 1.4rem;
-  box-shadow: 0 15px 30px rgba(44, 26, 12, 0.15);
+  gap: 0.6rem;
+  border: 2px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  border-radius: 0;
+  background: #ffffff;
+  padding: 0.5rem 0.8rem;
+  box-shadow: none;
   position: relative;
-  overflow: hidden;
-  animation: parchmentEnter 420ms ease both;
+  overflow: visible;
+  animation: retroEnter 200ms ease both;
 }
 
 .todo-item::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(90deg, rgba(111, 88, 62, 0.12), transparent 35%);
-  pointer-events: none;
+  content: none;
 }
 
 .todo-item::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 18px;
-  width: 4px;
-  border-radius: 999px;
-  background: linear-gradient(180deg, rgba(194, 154, 96, 0.45), rgba(143, 102, 54, 0.45));
+  content: none;
 }
 
 .todo-item.is-done {
-  background: linear-gradient(180deg, rgba(191, 199, 139, 0.35), rgba(245, 242, 224, 0.8));
-  border-color: rgba(120, 146, 88, 0.6);
-  opacity: 0.9;
+  background: #e8e8e8;
+  border-color: var(--win-mid) var(--win-light) var(--win-light) var(--win-mid);
+  opacity: 0.85;
 }
 
 .todo-main {
   display: inline-flex;
   align-items: center;
-  gap: 1rem;
-  font: 500 1rem/1.3 'Noto Serif KR', serif;
-  color: var(--ink);
+  gap: 0.6rem;
+  font: 400 1.2rem/1.3 'VT323', monospace;
+  color: var(--text-primary);
+  cursor: pointer;
 }
 
 .todo-main input[type='checkbox'] {
   appearance: none;
-  width: 1.4rem;
-  height: 1.4rem;
-  border-radius: 50%;
-  border: 2px solid rgba(67, 40, 18, 0.5);
-  background: linear-gradient(180deg, #f4dcc5, #f0d2b4);
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0;
+  border: 2px solid;
+  border-color: var(--win-dark) var(--win-light) var(--win-light) var(--win-dark);
+  background: #ffffff;
   display: grid;
   place-items: center;
   margin: 0;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.08);
-  transition: border-color 180ms ease, background 180ms ease, box-shadow 180ms ease;
+  box-shadow: none;
+  transition: none;
+  cursor: pointer;
 }
 
 .todo-main input[type='checkbox']::after {
   content: '';
-  width: 0.55rem;
-  height: 0.9rem;
-  border: 0.2rem solid var(--accent-stamp);
+  width: 0.45rem;
+  height: 0.7rem;
+  border: 2px solid var(--text-primary);
   border-top: 0;
   border-left: 0;
   transform: rotate(40deg);
   opacity: 0;
-  transition: opacity 150ms ease;
+  transition: opacity 100ms;
 }
 
 .todo-main input[type='checkbox']:checked {
-  background: linear-gradient(180deg, #f7ede1, #cbd59c);
-  border-color: var(--accent-sage);
-  box-shadow: 0 0 0 3px rgba(191, 199, 139, 0.3);
+  background: var(--accent-lime);
+  border-color: var(--win-dark) var(--win-light) var(--win-light) var(--win-dark);
+  box-shadow: none;
 }
 
 .todo-main input[type='checkbox']:checked::after {
@@ -396,104 +382,88 @@ button:focus-visible {
 }
 
 .todo-main span {
-  transition: color 160ms ease;
+  transition: none;
 }
 
 .todo-item.is-done .todo-main span {
-  color: rgba(63, 60, 45, 0.7);
+  color: var(--win-mid);
   text-decoration: line-through;
 }
 
 .delete-btn {
-  background: var(--accent-stamp);
-  color: #fff6f0;
-  padding: 0.45rem 1rem;
-  border-radius: 12px;
-  border: 1px solid rgba(36, 11, 7, 0.3);
-  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.2);
-  font-size: 0.7rem;
-  letter-spacing: 0.14em;
+  background: var(--win-face);
+  color: var(--danger);
+  padding: 0.15rem 0.6rem;
+  border-radius: 0;
+  border: 2px solid;
+  border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
+  box-shadow: none;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
 }
 
 .delete-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.2), 0 10px 18px rgba(194, 65, 50, 0.4);
+  background: var(--danger);
+  color: #ffffff;
+  transform: none;
+  box-shadow: none;
 }
 
 .empty {
   text-align: center;
-  border: 2px dashed rgba(109, 91, 74, 0.5);
-  border-radius: 28px;
-  padding: 1.8rem 1rem;
-  font: 500 0.95rem/1.6 'Song Myung', serif;
-  color: var(--ink-muted);
-  background: repeating-linear-gradient(
-      -45deg,
-      rgba(255, 255, 255, 0.5),
-      rgba(255, 255, 255, 0.5) 6px,
-      transparent 6px,
-      transparent 12px
-    ),
-    linear-gradient(180deg, rgba(253, 244, 227, 0.85), rgba(241, 226, 201, 0.85));
+  border: 2px dashed var(--win-mid);
+  border-radius: 0;
+  padding: 1.5rem 1rem;
+  font: 400 1.2rem/1.6 'VT323', monospace;
+  color: var(--text-muted);
+  background: #ffffff;
+  animation: retroEnter 200ms ease both;
 }
 
 .todo-footer {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.4rem;
   flex-wrap: wrap;
+  padding: 0.5rem 0.8rem 0.8rem;
+  border-top: 2px solid var(--win-mid);
 }
 
 .todo-footer span {
-  border: 1.5px solid rgba(96, 63, 31, 0.4);
-  border-radius: 16px;
-  padding: 0.6rem 1rem;
-  font: 600 0.75rem/1 'Noto Serif KR', serif;
-  text-transform: uppercase;
-  color: var(--ink);
-  background: linear-gradient(180deg, #fdf5e6, #f1e0c7);
-  letter-spacing: 0.25em;
+  border: 2px solid;
+  border-color: var(--win-dark) var(--win-light) var(--win-light) var(--win-dark);
+  border-radius: 0;
+  padding: 0.25rem 0.6rem;
+  font: 400 1rem/1 'VT323', monospace;
+  text-transform: none;
+  color: var(--text-primary);
+  background: #ffffff;
+  letter-spacing: 0.02em;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .todo-footer span::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 10px;
-  width: 1px;
-  background: rgba(143, 102, 54, 0.35);
+  content: none;
 }
 
 .todo-footer span::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.3), transparent);
-  opacity: 0.5;
+  content: none;
 }
 
-.empty,
-.todo-item {
-  animation: parchmentEnter 420ms ease both;
-}
-
-@keyframes parchmentEnter {
+@keyframes retroEnter {
   from {
     opacity: 0;
-    transform: translateY(14px) scale(0.98);
+    transform: translateY(4px);
   }
   to {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translateY(0);
   }
 }
 
 @media (max-width: 560px) {
   .todo-shell {
-    padding: 1.5rem;
-    border-radius: 24px;
+    padding: 0;
   }
 
   .todo-form {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -71,9 +71,9 @@ function App() {
     <main className="todo-page">
       <section className="todo-shell">
         <header className="todo-header">
-          <p className="eyebrow">Joseon Record Office</p>
-          <h1>할 일 장부</h1>
-          <p className="subtitle">[筆記臺帳 • LOCAL STORAGE]</p>
+          <p className="eyebrow">My_ToDo.exe</p>
+          <h1>~ TO DO LIST ~</h1>
+          <p className="subtitle">Powered by LOCAL STORAGE v1.0</p>
         </header>
 
         <form className="todo-form" onSubmit={addTodo}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,9 +10,9 @@ body,
 }
 
 body {
-  font-family: 'Noto Serif KR', 'Song Myung', serif;
-  color: var(--ink);
-  background: radial-gradient(circle at 30% 20%, #fdf2df 0%, #f1e0c8 55%, #d9c0a4 100%);
+  font-family: 'VT323', monospace;
+  color: #000000;
+  background: #008080;
   text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
+  -webkit-font-smoothing: none;
 }


### PR DESCRIPTION
Closes #19

## 변경 요약
- 조선시대 장부 스타일에서 **1990년대 Windows 95 스타일 레트로 디자인**으로 전면 변경
- 컬러 팔레트: teal 배경(#008080), 회색 윈도우(#c0c0c0), 3D 베벨 테두리, hot pink/cyan/lime 액센트
- 타이포그래피: `Press Start 2P` (픽셀 헤더) + `VT323` (모노스페이스 본문)
- UI 요소: border-radius 제거, Windows 95식 입체 버튼, 타이틀바 그라데이션, 체크박스 lime green 피드백

## 수정된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `frontend/src/App.css` | 전체 스타일 교체 — Win95 컬러 변수, 베벨 보더, 픽셀 폰트, 레트로 애니메이션 |
| `frontend/src/App.jsx` | 헤더 텍스트 변경 (My_ToDo.exe, ~ TO DO LIST ~, Powered by LOCAL STORAGE v1.0) |
| `frontend/src/index.css` | body 폰트/배경색/렌더링 변경 (VT323, teal, font-smoothing: none) |

## 검증 결과
- typecheck: ⏭️ (해당 없음 — JavaScript 프로젝트)
- build: ❌ (worktree 환경에 node_modules 미설치로 vite 실행 불가 — 코드 문제 아닌 환경 문제)
- unit test: ⏭️ (해당 없음)

## 셀프리뷰
- **보안**: 외부 입력 처리 변경 없음, XSS/injection 위험 없음
- **타입 안전성**: JSX 변경은 문자열 리터럴만 교체, 로직 변경 없음
- **패턴 일관성**: 기존 CSS 구조(커스텀 프로퍼티 → 페이지 → 셸 → 헤더 → 폼 → 리스트 → 푸터 → 미디어쿼리) 동일하게 유지
- **불필요한 변경**: 없음 — 스타일과 헤더 텍스트만 변경

## 리뷰 포인트
- `Press Start 2P` 웹폰트 로딩 시 FOUT(Flash of Unstyled Text) 확인
- 모바일(560px 이하) 반응형 레이아웃이 베벨 보더와 잘 맞는지 확인
- 실제 브라우저에서 teal 배경 + 회색 윈도우 조합의 가독성 확인

## ✅ 결과: 완료

### 판정 근거
- 요구사항(1990년대 레트로 디자인)을 Windows 95 스타일로 충실히 구현
- 기존 HTML 구조 변경 없이 CSS + 헤더 텍스트만 교체하여 변경 범위 최소화
- 빌드 실패는 worktree 환경의 node_modules 부재로 인한 것이며 코드 자체 문제 아님